### PR TITLE
Enable beta sign.

### DIFF
--- a/webapp/app-settings.json
+++ b/webapp/app-settings.json
@@ -1,5 +1,6 @@
 {
     "public": {
+        "showBetaSign": true,
         "elasticEndpoint": "http://staging.openskope.org/es"
     },
 


### PR DESCRIPTION
This option is read at https://github.com/openskope/skope-interface/blob/4b55ad3621f2a7280eb70ae4674e6caf315cb437/meteor-app/imports/ui/consts.js#L42.