### PR TITLE
Add sentry DSN to enable error tracking.

### DIFF
--- a/webapp/app-settings.json
+++ b/webapp/app-settings.json
@@ -1,9 +1,14 @@
 {
     "public": {
         "userGuideUrl": "http://www.openskope.org/skope-users-guide",
+        "sentry": {
+            "dsn": "https://30f9cbdacfcd418a9470d8a38f6fe0b2@sentry.io/1208020"
+        },
         "elasticEndpoint": "http://staging.openskope.org/es"
     },
-
+    "sentry": {
+        "dsn": "https://30f9cbdacfcd418a9470d8a38f6fe0b2@sentry.io/1208020"
+    },
     "server": {
         "elasticEndpoint": "http://elasticsearch:9200"
     }


### PR DESCRIPTION
This DSN is for production server.
The reason for having slots for two separate DSN entries for client and server is so that we could divide the logs into two projects in case we need to.

For `>= 0.1.13`, having this setting option would automatically enable error tracking.